### PR TITLE
Update gem include line

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ We use this gem to ensure the correct installation of a few OpsCare dependencies
 Add this line to the application's Gemfile:
 
 ```ruby
-gem "ops_care", github: "reinteractive/OpsCare", branch: "master"
+gem "ops_care", git: "git@github.com:reinteractive/OpsCare.git", branch: "master"
 ```
 
 And then bundle all the things:


### PR DESCRIPTION
Current Gemfile line produces warnings/errors when I've tried it, I suspect the syntax is slightly out-of-date.
Updated it to be more copy+paste friendly and matches what I've seen in a few repos we have under OpsCare