### PR TITLE
Fix deploy healthcheck version comparison

### DIFF
--- a/lib/generators/ops_care/templates/deploy_hooks/before_health_check.sh
+++ b/lib/generators/ops_care/templates/deploy_hooks/before_health_check.sh
@@ -3,7 +3,10 @@
 previous_working_dir=$PWD
 cd $current_app_path
 
-version=$(bundle exec rake opscare:healthcheck:default)
+healthcheck_output=$(bundle exec rake opscare:healthcheck:default)
+regex='opscare_helthcheck_sha:([a-z0-9]+)'
+[[ $healthcheck_output =~ $regex ]]
+version=${BASH_REMATCH[1]}
 
 if [ "$version" != "$requested_sha" ]; then
   echo "Healthcheck SHA ($version) doesn't match the requested one ($requested_sha)."

--- a/lib/generators/ops_care/templates/rake_tasks/opscare_healthcheck.rake
+++ b/lib/generators/ops_care/templates/rake_tasks/opscare_healthcheck.rake
@@ -14,7 +14,7 @@ namespace :opscare do
       version = version_check[/Version: (.*)/,1]
 
       # return the sha for bash to compare
-      puts version
+      puts "opscare_helthcheck_sha:#{version}"
     end
   end
 end


### PR DESCRIPTION
* Added changes as per Envisage repo
* Checked the documents (READMEs) and all seem to include the deploy health check hook and rake task already